### PR TITLE
Fix for separating Server.Connection in the ServerWait* functions

### DIFF
--- a/APLSource/Admin-1/Version-1.aplf
+++ b/APLSource/Admin-1/Version-1.aplf
@@ -1,0 +1,2 @@
+ r←Version
+ r←'0.1.16-beta-1'

--- a/APLSource/Core-1/ServerWait-41.aplf
+++ b/APLSource/Core-1/ServerWait-41.aplf
@@ -5,7 +5,7 @@
      0≠↑r:s LogCongaError r
      _←s LogConga r
      (z o e d)←r
-     n←12↓o
+     n←{⍵↓⍨1+⍵⍳'.'}o
      c←s GetConnectionSpace n
      e≡'Block':s OnBlockServer c e d
      e≡'BlockLast':s OnBlockServer c e d   ⍝ WaitForData

--- a/APLSource/Core-1/ServerWaitHTTP-3c41.aplf
+++ b/APLSource/Core-1/ServerWaitHTTP-3c41.aplf
@@ -5,7 +5,7 @@
      0≠↑r:s LogCongaError r
      _←s LogConga r
      (z o e d)←r
-     n←12↓o
+     n←{⍵↓⍨1+⍵⍳'.'}o
      c←s GetConnectionSpace n
      ⍝ CHANGE 1
      ⍝ e≡'WSReceive':s OnWSReceive c d ⍝ Now in WaitForDataHTTPCase

--- a/APLSource/Core-1/ServerWaitHTTPConnectionOnly-1007c41.aplf
+++ b/APLSource/Core-1/ServerWaitHTTPConnectionOnly-1007c41.aplf
@@ -4,8 +4,7 @@
      0≠↑r:s LogCongaError r
      _←s LogConga r
      (z o e d)←r
-     ⎕←e
-     n←12↓o
+     n←{⍵↓⍨1+⍵⍳'.'}o
      e≡'Connect':s OnConnect n
      e≡'Timeout':0
      e≡'Error':0


### PR DESCRIPTION
These functions:

```
#.Rumba.Core.ServerWait
#.Rumba.Core.ServerWaitHTTP
#.Rumba.Core.ServerWaitHTTPConnectionOnly
```

all do a `12↓` on a string that is usually something like `SRV00000000.CON00000257` in case a connection was attempted, resulting in `CON00000257`.

That was okay in a (now distant) past, but these days, one can overwrite the default server name. I do for the Tatin server, and as a result I get `Plodder.CON00000257`, and that results in `0000257` which is not a valid APL name and will cause a crash soon.

Therefore, it has to be `{⍵↓⍨1+⍵⍳'.'}` rather than `12↓`

I've created a pull request with this change. I've also removed line [6] from this function:

```
∇ ServerWaitHTTPConnectionOnly←{
[1] s←⍵
[2] r←s.DRC.Wait s.Name s.CongaTimeout
[3] 0≠↑r:s LogCongaError r
[4] _←s LogConga r
[5] (z o e d)←r
[6] ⎕←e
[7] n←12↓o
[8] e≡'Connect':s OnConnect n
[9] e≡'Timeout':0
[10] e≡'Error':0
[11] 0
[12] }
∇
```

There is one more thing: neither `ServerWaitHTTP` nor `ServerWaitHTTPConnectionOnly` by any test.

Finally, I have added a function `#.Rumba.Admin.Version`. Right now, it returns `0.1.16-beta-1`

I would very much appreciate it if Rumba would tell me which version I am currently using.